### PR TITLE
a11y: set background color

### DIFF
--- a/styles/simple/global.css
+++ b/styles/simple/global.css
@@ -3,6 +3,7 @@
 body {
 	font-family: sans-serif;
 	padding: 0 5%;
+	background-color: #ffffff;
 }
 
 a:link {


### PR DESCRIPTION
Setting a foreground color without also setting a background color can mess up contrast among users whose browsers use default color schemes that aren't black-on-white.

Fixes #9